### PR TITLE
Feat: payload object화 및 인가 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,20 @@ DATABASE_DATABASE=<database_name> # 접속하려는 데이터베이스의 이름
 
 IS_DEVELOPE=dev # 개발시에는 dev, 서비스시에는 prod
 
+# Comment Limit
+COMMENT_LIMIT=20
+
 # AWS S3
 AWS_S3_BUCKET_REGION=ap-northeast-2 # S3 버킷이 있는 지역
 AWS_S3_ACCESS_KEY_ID=<access_key> # IAM에서 발급한 버킷 접근 Key
 AWS_S3_SECRET_ACCESS_KEY=<secret_access_key> # IAM에서 발급한 버킷 접근 Secret Accecc Key
 AWS_S3_BUCKET_NAME=<bucket_name> # S3 버킷 이름
 AWS_S3_BUCKER_URL=<bucket_url> # S3 버킷 주소
+
+# token
+JWT_SECRET="ivno********njkn"
+ACCESS_TOKEN_EXPIRE="2h"
+REFRESH_TOKEN_EXPIRT="7d"
 ```
 
 
@@ -159,4 +167,30 @@ const command = new DeleteObjectsCommand({
 })
 
 s3.send(command); // 커맨드 전송
+```
+
+## 인가 관련
+
+`@Roles()` 를 통한 인가 기능 추가. 만약 더 추가하고싶은 역할이 있다면 `token-payload.obj.ts`의 enum에 추가하고 `TokenPayload` 클래스의 constructor만 수정해주세용
+
+※ 단, constructor 수정 시 `roles.guard.ts` 로직 수정 필요. 현재는 Admin과 User 2개만 있다 가정하고 만들었음
+
+```ts
+1. 권한을 부여하지 않는 경우
+  이 경우는 @Roles() 데코레이션을 사용하지 않거나, @Roles() 데코레이터 안에 아무것도 쓰지 않으면 된다.
+  e.g.)
+  1)
+    @Roles()
+    async fetchSometing()
+  2)
+    async fetchSomething()
+
+2. 권한을 부여하는 경우
+ 이 경우는 @Roles() 데코레이터 안에 원하는 권한을 넣으면 된다.
+  e.g.)
+    @Roles(Role.Admin)
+    async postSomething()
+
+    @Roles(Role.User)
+    async fetchSomething()
 ```

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -14,6 +14,7 @@ import bcrypt from "bcrypt";
 import { RegisterDto } from "./dto/register.dto";
 import { UserTitleService } from "src/user/service/user-title.service";
 import { PlateSettingService } from "src/user/service/plate-setting.service";
+import { TokenPayload } from "./object/token-payload.obj";
 
 const SALT_ROUNDS = 10;
 @Injectable()
@@ -32,19 +33,18 @@ export class AuthService {
     if (!user) throw new NotFoundException("User not found");
 
     if (bcrypt.compareSync(loginDto.password, user.password)) {
+      const payload = new TokenPayload(user);
       let accessToken = await this.jwtService.signAsync(
         {
-          uid: user.userId,
-          username: user.registerId,
+          ...payload,
         },
-        { expiresIn: "1h" },
+        { expiresIn: process.env.ACCESS_TOKEN_EXPIRE },
       );
       let refreshToken = await this.jwtService.signAsync(
         {
-          uid: user.userId,
-          username: user.registerId,
+          ...payload,
         },
-        { expiresIn: "7d" },
+        { expiresIn: process.env.REFRESH_TOKEN_EXPIRE },
       );
 
       accessToken = "Bearer " + accessToken;

--- a/src/auth/object/token-payload.obj.ts
+++ b/src/auth/object/token-payload.obj.ts
@@ -1,0 +1,20 @@
+import { User } from "src/user/entity/user.entity";
+
+export class TokenPayload {
+  uid: number;
+  registerId: string; // username을 registerId로 변경
+  nickname: string;
+  role: Role;
+
+  constructor(user: User) {
+    this.uid = user.userId;
+    this.registerId = user.registerId;
+    this.nickname = user.nickname;
+    this.role = user.adminYn === true ? Role.Admin : Role.User;
+  }
+}
+
+export enum Role {
+  User = "User",
+  Admin = "Admin",
+}

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -13,7 +13,8 @@ import { CreateBoardDto } from "./dto/create-board.dto";
 import { ModifyBoardDto } from "./dto/modify-board.dto";
 import { PostService } from "src/post/post.service";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
-import { SkipAuth } from "src/token/token.metadata";
+import { Roles, SkipAuth } from "src/token/token.metadata";
+import { Role } from "src/auth/object/token-payload.obj";
 
 @Controller("board")
 @ApiTags("board")
@@ -52,6 +53,7 @@ export class BoardController {
     return result;
   }
 
+  @Roles(Role.Admin)
   @Post()
   @ApiOperation({})
   async createBoard(@Body() boardInfo: CreateBoardDto) {
@@ -59,6 +61,7 @@ export class BoardController {
     return result;
   }
 
+  @Roles(Role.Admin)
   @Delete(":originName")
   @ApiOperation({})
   async deleteBoard(@Param("originName") originName) {
@@ -66,6 +69,7 @@ export class BoardController {
     return result;
   }
 
+  @Roles(Role.Admin)
   @Patch(":originName")
   @ApiOperation({})
   async updateBoard(

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { TokenGuard } from "./token/token.guard";
 import { winstonLogger } from "./config/logger.config";
 import { setupSwagger } from "./config/swagger.config";
 import { json } from "express";
+import { RolesGuard } from "./token/roles.guard";
 
 async function bootstrap() {
   const isDevelope = process.env.IS_DEVELOPE === "dev" ? true : false;
@@ -23,7 +24,10 @@ async function bootstrap() {
   });
   const jwtService = app.get(JwtService);
   const reflector = app.get(Reflector);
-  app.useGlobalGuards(new TokenGuard(jwtService, reflector));
+  app.useGlobalGuards(
+    new TokenGuard(jwtService, reflector),
+    new RolesGuard(reflector),
+  );
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/src/token/roles.guard.ts
+++ b/src/token/roles.guard.ts
@@ -1,0 +1,44 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Observable } from "rxjs";
+import { Role, TokenPayload } from "src/auth/object/token-payload.obj";
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const roles = this.reflector.getAllAndOverride<Role[]>("roles", [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    const req = context.switchToHttp().getRequest();
+    const user: TokenPayload = req.user;
+
+    // @Roles 데코레이터가 없을 때
+    if (!roles) {
+      return true;
+    }
+    // @Roles() 만 적힌 경우. 즉 결과값이 []인 경우
+    if (!roles.length) {
+      return true;
+    }
+    // @Roles(Role.Admin) 등과 같이 적힌 경우
+    // Admin인 경우 무조건 통과
+    if (user.role === Role.Admin) {
+      return true;
+    }
+    // 해당 권한이 있다면 통과
+    if (roles.includes(user.role) === true) {
+      return true;
+    }
+    throw new ForbiddenException("접근 권한이 없습니다.");
+  }
+}

--- a/src/token/token.guard.ts
+++ b/src/token/token.guard.ts
@@ -9,6 +9,7 @@ import { JwtService } from "@nestjs/jwt";
 import { Response } from "express";
 import { Observable } from "rxjs";
 import { IS_PUBLIC_KEY } from "./token.metadata";
+import { TokenPayload } from "src/auth/object/token-payload.obj";
 
 type Cookies = {
   access_token: string;
@@ -45,33 +46,42 @@ export class TokenGuard implements CanActivate {
     const jwtSecret = process.env.JWT_SECRET;
 
     try {
-      const decodedAccessToken = this.jwtService.verify(cookies.access_token, {
-        secret: jwtSecret,
-      });
-      console.log(decodedAccessToken);
+      const decodedAccessToken = this.getPayload(
+        cookies.access_token,
+        jwtSecret,
+      );
       request.user = decodedAccessToken;
       return true;
     } catch (accessTokenError) {
       try {
-        const decodedRefreshToken = this.jwtService.verify(
+        const decodedRefreshToken: TokenPayload = this.getPayload(
           cookies.refresh_token,
-          {
-            secret: jwtSecret,
-          },
+          jwtSecret,
         );
-        const newAccessToken = this.jwtService.sign(
+        const newAccessToken: string = this.jwtService.sign(
           {
-            uid: decodedRefreshToken.uid,
-            username: decodedRefreshToken.username,
+            ...decodedRefreshToken,
           },
-          { expiresIn: "1h", secret: jwtSecret },
+          { expiresIn: process.env.ACCESS_TOKEN_EXPIRE, secret: jwtSecret },
         );
         request.user = decodedRefreshToken;
         response.cookie("access_token", newAccessToken, { httpOnly: true });
         return true;
       } catch (refreshTokenError) {
+        // token expire 시 토큰 자체를 삭제.
+        // access_token을 header로 보낼 경우 clearCookie 대신 clearHeader로 바꿔야할듯?
+        response.clearCookie("access_token", { httpOnly: true });
+        response.clearCookie("refresh_token", { httpOnly: true });
         throw new UnauthorizedException("Token expired");
       }
     }
+  }
+
+  getPayload(token: string, secret: string): TokenPayload {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { iat, exp, ...payload } = this.jwtService.verify(token, {
+      secret: secret,
+    });
+    return payload;
   }
 }

--- a/src/token/token.metadata.ts
+++ b/src/token/token.metadata.ts
@@ -2,3 +2,4 @@ import { SetMetadata } from "@nestjs/common";
 
 export const IS_PUBLIC_KEY = "isPublic";
 export const SkipAuth = () => SetMetadata(IS_PUBLIC_KEY, true);
+export const Roles = (...roles: string[]) => SetMetadata("roles", roles);


### PR DESCRIPTION
- payload의 내용에는 uid, registerId(구 username), nickname, role이 담김.
- 이에 따른 jwt sign 함수 로직 수정

- jwt sign에 들어가는 expire을 env로 따로 관리 → 이에 따른 auth.service.ts, tokeh.guard.ts 수정

인가 기능 구현
- 전역 guard 역할을 하는 roles.guars.ts 제작
- token.metadata.ts에 인가할 수 있게 하는 데코레이터 제작
- main.ts에 globalGuard를 설정. TokenGuard 이후 RolesGuard를 사용하도록 체이닝

Readme 수정
- .env 관련 데이터 수정
- Roles 데코레이터 사용 방법 추가

board에 인가 테스트용 데코레이터 추가