### PR TITLE
Feat: 진행도 관련 엔드포인트 개발 

### DIFF
--- a/src/pattern/entity/practice.entity.ts
+++ b/src/pattern/entity/practice.entity.ts
@@ -29,6 +29,15 @@ export class Practice {
   @Column()
   level: number;
 
+  @Column({
+    type: "decimal",
+    precision: 7,
+    scale: 2,
+    comment: "00000.00~99999.99",
+    default: 0, // 임시로 만들었음
+  })
+  goalRate: number; // DECIMAL(7,2)
+
   @Column()
   keyNum: number;
 

--- a/src/pattern/service/level-test.service.ts
+++ b/src/pattern/service/level-test.service.ts
@@ -28,14 +28,33 @@ export class LevelTestService {
     return await this.levelTestRepo.save(levelTest);
   }
 
-  async fetchById(id: number): Promise<LevelTest> {
-    return await this.findLevelTest(id);
+  async fetchById(
+    id: number,
+    includePatternInfo: boolean = false,
+  ): Promise<LevelTest> {
+    return await this.findLevelTest(id, includePatternInfo);
   }
 
-  async fetchAll() {
+  async fetchByTitle(title: string): Promise<LevelTest> {
+    const res = await this.levelTestRepo.findOne({
+      where: {
+        title: title,
+      },
+    });
+    return res;
+  }
+
+  async fetchAll(keyNum?: number) {
+    const whereClues = {};
+    if (Number.isNaN(keyNum) === false && keyNum != null) {
+      whereClues["keyNum"] = keyNum;
+    }
     return await this.levelTestRepo.find({
       relations: {
         patternInfo: true,
+      },
+      where: {
+        ...whereClues,
       },
     });
   }
@@ -44,7 +63,7 @@ export class LevelTestService {
     id: number,
     updateData: UpdateLevelTestDto,
   ): Promise<LevelTest> {
-    const levelTest: LevelTest = await this.findLevelTest(id);
+    const levelTest: LevelTest = await this.findLevelTest(id, true);
 
     if (updateData.patternInfo !== undefined) {
       updateData.patternInfo =
@@ -59,20 +78,24 @@ export class LevelTestService {
       ...updateData,
     };
     await this.levelTestRepo.save(updateLevelTestData);
-    return await this.findLevelTest(id);
+    return await this.findLevelTest(id, true);
   }
 
   async deleteById(id: number) {
     return await this.levelTestRepo.delete(id);
   }
 
-  async findLevelTest(id: number): Promise<LevelTest> {
+  async findLevelTest(
+    id: number,
+    includePatternInfo: boolean,
+  ): Promise<LevelTest> {
+    const relationsClue = includePatternInfo ? { patternInfo: true } : {};
     return await this.levelTestRepo.findOne({
       where: {
         testId: id,
       },
       relations: {
-        patternInfo: true,
+        ...relationsClue,
       },
     });
   }

--- a/src/progress/dto/update-progress.dto.ts
+++ b/src/progress/dto/update-progress.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNumber } from "class-validator";
+import { IsNotEmpty, IsNumber } from "class-validator";
 
 export class UpdateProgressDto {
   @ApiProperty({
@@ -8,5 +8,6 @@ export class UpdateProgressDto {
     description: "달성도를 적어주시면 됩니다",
   })
   @IsNumber()
+  @IsNotEmpty()
   progress: number;
 }

--- a/src/progress/entity/level-test-progress.entity.ts
+++ b/src/progress/entity/level-test-progress.entity.ts
@@ -1,14 +1,17 @@
 import { LevelTest } from "src/pattern/entity/level-test.entity";
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
 import { User } from "../../user/entity/user.entity";
 
 @Entity()
 export class LevelTestProgress {
   @PrimaryGeneratedColumn()
   levelTestProgressId: number;
-
-  @Column({ type: "decimal", precision: 5, scale: 2, comment: "000.00~999.99" })
-  currentRate: number;
 
   @ManyToOne(() => User, (user) => user.levelTestProgresses, {
     onDelete: "CASCADE",
@@ -19,4 +22,10 @@ export class LevelTestProgress {
     onDelete: "CASCADE",
   })
   levelTest: LevelTest;
+
+  @Column({ type: "decimal", precision: 5, scale: 2, comment: "000.00~999.99" })
+  currentRate: number;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/src/progress/entity/practice-progress.entity.ts
+++ b/src/progress/entity/practice-progress.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
 import { User } from "../../user/entity/user.entity";
 import { Practice } from "src/pattern/entity/practice.entity";
 
@@ -6,9 +12,6 @@ import { Practice } from "src/pattern/entity/practice.entity";
 export class PracticeProgress {
   @PrimaryGeneratedColumn()
   practiceProgressId: number;
-
-  @Column({ type: "decimal", precision: 5, scale: 2, comment: "000.00~999.99" })
-  currentRate: number;
 
   @ManyToOne(() => User, (user) => user.practiceProgresses, {
     onDelete: "CASCADE",
@@ -19,4 +22,10 @@ export class PracticeProgress {
     onDelete: "CASCADE",
   })
   practice: Practice;
+
+  @Column({ type: "decimal", precision: 5, scale: 2, comment: "000.00~999.99" })
+  currentRate: number;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/src/progress/obj/swagger-properties.obj.ts
+++ b/src/progress/obj/swagger-properties.obj.ts
@@ -1,0 +1,98 @@
+const practiceProperty = (
+  title: string,
+  level: number,
+  goalRate: string,
+  keyNum: number,
+) => {
+  return {
+    type: "object",
+    properties: {
+      currentRate: { type: "string", example: "90.11" },
+      updatedAt: { type: "string", example: "2024-03-23T04:16:36.000Z" },
+      practice: {
+        type: "object",
+        properties: {
+          title: { type: "string", example: title },
+          level: { type: "number", example: level },
+          goalRate: { type: "string", example: goalRate },
+          keyNum: { type: "number", example: keyNum },
+        },
+      },
+    },
+  };
+};
+
+const levelTestProperty = (title: string, level: number, keyNum: number) => {
+  return {
+    type: "object",
+    properties: {
+      currentRate: { type: "string", example: "90.11" },
+      updatedAt: { type: "string", example: "2024-03-23T04:16:36.000Z" },
+      levelTest: {
+        type: "object",
+        properties: {
+          title: { type: "string", example: title },
+          level: { type: "number", example: level },
+          keyNum: { type: "number", example: keyNum },
+        },
+      },
+    },
+  };
+};
+
+const getAllOnesProperty = (type: string, keynum: number) => {
+  return {
+    type: "array",
+    items: {
+      oneOf:
+        type === "practice"
+          ? [
+              practiceProperty("practice1", 4, "92.3", keynum),
+              practiceProperty("practice2", 4, "92.6", keynum),
+              practiceProperty("practice3", 4, "92.1", keynum),
+            ]
+          : [
+              levelTestProperty("test1", 4, keynum),
+              levelTestProperty("test1", 4, keynum),
+            ],
+    },
+  };
+};
+
+export const getAllOnesPropertyWithKeynum = (type: string) => {
+  return {
+    type: "object",
+    properties: {
+      4: getAllOnesProperty(type, 4),
+      5: getAllOnesProperty(type, 5),
+    },
+  };
+};
+
+const rankingProperty = (rate: string, updatedAt: string, name: string) => {
+  return {
+    type: "object",
+    properties: {
+      currentRate: { type: "string", example: rate },
+      updatedAt: { type: "Date", example: updatedAt },
+      user: {
+        type: "object",
+        properties: {
+          nickname: { type: "string", example: name },
+        },
+      },
+    },
+  };
+};
+
+export const getRankingProperties = () => {
+  return {
+    type: "array",
+    items: {
+      oneOf: [
+        rankingProperty("90.12", "2024-03-23T23:46:32.897Z", "admin"),
+        rankingProperty("90.11", "2024-03-23T04:16:36.000Z", "John Doe"),
+      ],
+    },
+  };
+};

--- a/src/progress/progress.controller.ts
+++ b/src/progress/progress.controller.ts
@@ -1,72 +1,280 @@
-import { Body, Controller, Get, Param, Post, Req, Res } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Req,
+  Res,
+} from "@nestjs/common";
 import { ProgressService } from "./service/progress.service";
-import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from "@nestjs/swagger";
 import { UpdateProgressDto } from "./dto/update-progress.dto";
 import { Response } from "express";
+import { TokenPayload } from "src/auth/object/token-payload.obj";
+import {
+  getAllOnesPropertyWithKeynum,
+  getRankingProperties,
+} from "./obj/swagger-properties.obj";
+import { SkipAuth } from "src/token/token.metadata";
 
 @Controller("progress")
 @ApiTags("progress")
 export class ProgressController {
   constructor(private readonly progressService: ProgressService) {}
 
-  @Get("level-test/:testId")
-  @ApiOperation({})
+  @Get("level-test/spec/:testId")
+  @ApiParam({
+    name: "testId",
+    description: "특정 레벨 테스트 달성도를 조회하기 위한 레벨테스트 id",
+  })
+  @ApiOperation({ summary: "유저의 레벨 테스트 달성도 조회" })
+  @ApiOkResponse({
+    description: "레벨 테스트 달성도 조회 성공",
+    schema: {
+      type: "object",
+      properties: {
+        currentRate: { type: "string", example: "90.01" },
+        updatedAt: { type: "string", example: "2024-03-23T03:50:36.000Z" },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: "레벨 테스트 달성도 조회 실패",
+    schema: { type: "string", example: "레벨 테스트 결과 없음" },
+  })
   async fetchLevelTestProgress(
     @Req() req,
     @Res() res: Response,
     @Param("testId") testId,
   ) {
-    const user = req.user;
+    const user: TokenPayload = req.user;
     const levelTestProgress = await this.progressService.fetchLeveltestProgress(
       +user.uid,
       +testId,
     );
-    res.status(200).send(levelTestProgress);
+    res.status(HttpStatus.OK).send(levelTestProgress);
+  }
+
+  @Get("level-test/all/:keyNum?")
+  @ApiOperation({ summary: "유저의 모든 레벨 테스트 달성도 조회" })
+  @ApiParam({
+    name: "keyNum",
+    description: "특정 키의 결과를 얻어오고 싶을 때 사용",
+    required: false,
+  })
+  @ApiOkResponse({
+    description: "조회 성공",
+    schema: getAllOnesPropertyWithKeynum("level-test"),
+  })
+  async fetchAllLevelTestProgress(
+    @Req() req,
+    @Res() res: Response,
+    @Param("keyNum") keyNum: number,
+  ) {
+    const user: TokenPayload = req.user;
+    const result = await this.progressService.fetchAllLevelTestProgress(
+      +user.uid,
+      +keyNum,
+    );
+    res.status(HttpStatus.OK).send(result);
   }
 
   @Post("level-test/:testId")
-  @ApiOperation({})
+  @ApiOperation({ summary: "레벨 테스트 달성도 업데이트/생성" })
+  @ApiCreatedResponse({
+    description: "레벨 테스트 달성도 생성 성공",
+    schema: {
+      type: "object",
+      properties: {
+        currentRate: { type: "number", example: 90.01 },
+        updatedAt: { type: "string", example: "2024-03-23T03:50:36.000Z" },
+      },
+    },
+  })
+  @ApiOkResponse({
+    description: "레벨 테스트 달성도 업데이트 성공 - null 값이 반환될 수 있음",
+    schema: {
+      type: "object",
+      properties: {
+        currentRate: { type: "number", example: 90.01 },
+        updatedAt: { type: "string", example: "2024-03-23T03:50:36.000Z" },
+      },
+      nullable: true,
+    },
+  })
+  @ApiBadRequestResponse({
+    description: "레벨 테스트 달성도 업데이트 실패",
+    schema: { type: "string", example: "해당 레벨 테스트는 없습니다." },
+  })
   async updateLevelTestProgress(
     @Req() req,
+    @Res() res: Response,
     @Body() body: UpdateProgressDto,
     @Param("testId") testId: number,
   ) {
-    const user = req.user;
-    return await this.progressService.updateLeveltestProgress(
+    const user: TokenPayload = req.user;
+    const result = await this.progressService.updateLeveltestProgress(
       +body.progress,
       +user.uid,
       +testId,
     );
+    if (result.type === "create") {
+      res.status(HttpStatus.CREATED).send(result.data);
+    } else {
+      res.status(HttpStatus.OK).send(result.data);
+    }
   }
 
-  @Get("practice/:practiceId")
-  @ApiOperation({})
+  @Get("practice/spec/:practiceId")
+  @ApiOperation({ summary: "유저의 패턴 연습 달성도 조회" })
+  @ApiOkResponse({
+    description: "패턴 연습 달성도 조회 성공",
+    schema: {
+      type: "object",
+      properties: {
+        currentRate: { type: "string", example: "90.01" },
+        updatedAt: { type: "string", example: "2024-03-23T03:50:36.000Z" },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: "패턴 연습 조회 실패",
+    schema: { type: "string", example: "패턴 연습 결과 없음" },
+  })
   async fetchPracticeProgress(
     @Req() req,
     @Res() res: Response,
     @Param("practiceId") practiceId: number,
   ) {
-    const user = req.user;
+    const user: TokenPayload = req.user;
     const practiceProgress =
       await await this.progressService.fetchPracticeProgress(
         +user.uid,
         +practiceId,
       );
-    res.status(200).send(practiceProgress);
+    res.status(HttpStatus.OK).send(practiceProgress);
+  }
+
+  @Get("practice/all/:keyNum?")
+  @ApiOperation({ summary: "유저의 모든 패턴 연습 달성도 조회" })
+  @ApiParam({
+    name: "keyNum",
+    description: "특정 키의 결과를 얻어오고 싶을 때 사용",
+    required: false,
+  })
+  @ApiOkResponse({
+    description: "조회 성공",
+    schema: getAllOnesPropertyWithKeynum("practice"),
+  })
+  async fetchAllPracticeProgress(
+    @Req() req,
+    @Res() res: Response,
+    @Param("keyNum") keyNum: number,
+  ) {
+    const user: TokenPayload = req.user;
+    const result = await this.progressService.fetchAllPracticeProgress(
+      +user.uid,
+      +keyNum,
+    );
+    res.status(HttpStatus.OK).send(result);
   }
 
   @Post("practice/:practiceId")
-  @ApiOperation({})
+  @ApiOperation({ summary: "패턴 연습 달성도 업데이트/생성" })
+  @ApiCreatedResponse({
+    description: "패턴 연습 달성도 생성 성공",
+    schema: {
+      type: "object",
+      properties: {
+        currentRate: { type: "number", example: 90.01 },
+        updatedAt: { type: "string", example: "2024-03-23T03:50:36.000Z" },
+      },
+    },
+  })
+  @ApiOkResponse({
+    description: "패턴 연습 달성도 업데이트 성공 - null 값이 반환될 수 있음",
+    schema: {
+      type: "object",
+      properties: {
+        currentRate: { type: "number", example: 90.01 },
+        updatedAt: { type: "string", example: "2024-03-23T03:50:36.000Z" },
+      },
+      nullable: true,
+    },
+  })
+  @ApiBadRequestResponse({
+    description: "패턴 연습 달성도 업데이트 실패",
+    schema: { type: "string", example: "해당 패턴 연습은 없습니다." },
+  })
   async updatePracticeProgress(
     @Req() req,
+    @Res() res: Response,
     @Body() body: UpdateProgressDto,
     @Param("practiceId") practiceId: number,
   ) {
-    const user = req.user;
-    return await this.progressService.updatePracticeProgress(
+    const user: TokenPayload = req.user;
+    const result = await this.progressService.updatePracticeProgress(
       +body.progress,
       +user.uid,
       +practiceId,
     );
+    if (result.type === "create") {
+      res.status(HttpStatus.CREATED).send(result.data);
+    } else {
+      res.status(HttpStatus.OK).send(result.data);
+    }
+  }
+
+  @SkipAuth()
+  @Get("ranking/level-test/:id")
+  @ApiParam({
+    name: "id",
+    description: "랭킹을 보고싶은 레벨 테스트의 id",
+  })
+  @ApiOkResponse({
+    description: "랭킹 조회 성공",
+    schema: getRankingProperties(),
+  })
+  @ApiBadRequestResponse({
+    description: "해당 레벨 테스트는 없음",
+    schema: {
+      type: "string",
+      example: "해당 레벨 테스트는 없습니다.",
+    },
+  })
+  async fetchLevetestRanking(@Res() res: Response, @Param("id") id: number) {
+    const result = await this.progressService.fetchLevelTestRanking(+id);
+    res.status(HttpStatus.OK).send(result);
+  }
+
+  @SkipAuth()
+  @Get("ranking/practice/:id")
+  @ApiParam({
+    name: "id",
+    description: "랭킹을 보고싶은 패턴 연습의 id",
+  })
+  @ApiOkResponse({
+    description: "랭킹 조회 성공",
+    schema: getRankingProperties(),
+  })
+  @ApiBadRequestResponse({
+    description: "해당 패턴 연습은 없음",
+    schema: {
+      type: "string",
+      example: "해당 패턴 연습은 없습니다.",
+    },
+  })
+  async fetchPracticeRanking(@Res() res: Response, @Param("id") id: number) {
+    const result = await this.progressService.fetchPracticeRanking(+id);
+    res.status(HttpStatus.OK).send(result);
   }
 }

--- a/src/progress/service/level-test-progress.service.ts
+++ b/src/progress/service/level-test-progress.service.ts
@@ -4,15 +4,21 @@ import { LevelTestProgress } from "../entity/level-test-progress.entity";
 import { User } from "src/user/entity/user.entity";
 import { Repository } from "typeorm";
 import { LevelTest } from "src/pattern/entity/level-test.entity";
+import { LevelTestService } from "src/pattern/service/level-test.service";
 
 @Injectable()
 export class LevelTestProgressService {
   constructor(
     @InjectRepository(LevelTestProgress)
     private progressRepo: Repository<LevelTestProgress>,
+    private readonly levelTestService: LevelTestService,
   ) {}
 
-  async update(progress: number, user: User, levelTest: LevelTest) {
+  async update(
+    progress: number,
+    user: User,
+    levelTest: LevelTest,
+  ): Promise<{ type: string; data: object }> {
     const res = await this.progressRepo.findOne({
       where: {
         user: {
@@ -23,11 +29,16 @@ export class LevelTestProgressService {
         },
       },
     });
+    let data: LevelTestProgress;
+    let type: string;
     if (res) {
-      this.__update(progress, res);
+      data = await this.__update(progress, res);
+      type = "update";
     } else {
-      this.__create(progress, user, levelTest);
+      data = await this.__create(progress, user, levelTest);
+      type = "create";
     }
+    return { type: type, data: data };
   }
 
   async fetch(userId: number, levelTestId: number) {
@@ -46,7 +57,94 @@ export class LevelTestProgressService {
         "해당 유저는 해당 레벨 테스트 결과를 가지고 있지 않습니다.",
       );
     }
-    delete res.levelTestProgressId;
+    return res;
+  }
+
+  async fetchAllByUserId(userId: number, keyNum: number) {
+    const whereClue = {
+      user: { userId: userId },
+    };
+    if (Number.isNaN(keyNum) === false) {
+      whereClue["levelTest"] = { keyNum: keyNum };
+    }
+    const levelTests = await this.levelTestService.fetchAll(keyNum);
+
+    const res = await this.progressRepo.find({
+      select: {
+        currentRate: true,
+        updatedAt: true,
+        levelTest: {
+          testId: true,
+        },
+      },
+      where: {
+        ...whereClue,
+      },
+      relations: {
+        levelTest: true,
+      },
+    });
+    const mappedRes = {};
+    levelTests.forEach((lTest: LevelTest) => {
+      if (mappedRes[lTest.keyNum] == null) {
+        mappedRes[lTest.keyNum] = [];
+      }
+      let currentRate = 0;
+      for (const [idx, progress] of res.entries()) {
+        if (progress.levelTest.testId === lTest.testId) {
+          currentRate = progress.currentRate;
+          res.splice(idx, 1);
+          break;
+        }
+      }
+
+      delete lTest.patternInfo.patternId;
+      for (const key in lTest.patternInfo) {
+        if (lTest.patternInfo[key] === 0) {
+          delete lTest.patternInfo[key];
+        }
+      }
+
+      mappedRes[lTest.keyNum].push({
+        goalRate: lTest.goalRate,
+        currentRate: currentRate,
+        level: lTest.level,
+        title: lTest.title,
+        imgSrc: lTest.imgSrc,
+        noteSrc: lTest.noteSrc,
+        musicSrc: lTest.musicSrc,
+        patternInfo: lTest.patternInfo,
+      });
+    });
+    return mappedRes;
+  }
+
+  async fetchRanking(id: number) {
+    const levelTest = await this.levelTestService.fetchById(id);
+    if (levelTest == null) {
+      throw new BadRequestException("해당 레벨 테스트는 없습니다.");
+    }
+    const res = await this.progressRepo.find({
+      select: {
+        currentRate: true,
+        updatedAt: true,
+        user: {
+          nickname: true,
+        },
+      },
+      where: {
+        levelTest: {
+          testId: levelTest.testId,
+        },
+      },
+      relations: {
+        user: true,
+      },
+      order: {
+        currentRate: "DESC",
+        updatedAt: "ASC",
+      },
+    });
     return res;
   }
 
@@ -55,18 +153,17 @@ export class LevelTestProgressService {
     entity.user = user;
     entity.levelTest = levelTest;
     entity.currentRate = progress;
-    return await this.progressRepo.save(entity);
+    const res = await this.progressRepo.save(entity);
+    delete res.user;
+    delete res.levelTest;
+    return res;
   }
 
   private async __update(progress: number, entity: LevelTestProgress) {
     if (entity.currentRate < progress) {
       entity.currentRate = progress;
-      this.progressRepo.update(
-        {
-          levelTestProgressId: entity.levelTestProgressId,
-        },
-        entity,
-      );
+      return await this.progressRepo.save(entity);
     }
+    return null;
   }
 }

--- a/src/progress/service/practice-progress.service.ts
+++ b/src/progress/service/practice-progress.service.ts
@@ -4,15 +4,21 @@ import { PracticeProgress } from "../entity/practice-progress.entity";
 import { Repository } from "typeorm";
 import { User } from "src/user/entity/user.entity";
 import { Practice } from "src/pattern/entity/practice.entity";
+import { PracticeService } from "src/pattern/service/practice.service";
 
 @Injectable()
 export class PracticeProgressService {
   constructor(
     @InjectRepository(PracticeProgress)
     private progressRepo: Repository<PracticeProgress>,
+    private readonly practiceService: PracticeService,
   ) {}
 
-  async update(progress: number, user: User, practice: Practice) {
+  async update(
+    progress: number,
+    user: User,
+    practice: Practice,
+  ): Promise<{ type: string; data: object }> {
     const res = await this.progressRepo.findOne({
       where: {
         user: {
@@ -23,11 +29,16 @@ export class PracticeProgressService {
         },
       },
     });
+    let data: PracticeProgress;
+    let type: string;
     if (res) {
-      this.__update(progress, res);
+      data = await this.__update(progress, res);
+      type = "update";
     } else {
-      this.__create(progress, user, practice);
+      data = await this.__create(progress, user, practice);
+      type = "create";
     }
+    return { type: type, data: data };
   }
 
   async fetch(userId: number, practiceId: number) {
@@ -46,7 +57,93 @@ export class PracticeProgressService {
         "해당 유저는 해당 패턴 연습 결과를 가지고 있지 않습니다.",
       );
     }
-    delete res.practiceProgressId;
+    return res;
+  }
+
+  async fetchAllByUserId(userId: number, keyNum: number) {
+    const whereClue = {
+      user: { userId: userId },
+    };
+    if (Number.isNaN(keyNum) === false) {
+      whereClue["practice"] = { keyNum: keyNum };
+    }
+    const practices = await this.practiceService.fetchAll(keyNum);
+
+    const res = await this.progressRepo.find({
+      select: {
+        currentRate: true,
+        updatedAt: true,
+        practice: {
+          practiceId: true,
+        },
+      },
+      where: {
+        ...whereClue,
+      },
+      relations: {
+        practice: true,
+      },
+    });
+    const mappedRes = {};
+    practices.forEach((practice: Practice) => {
+      if (mappedRes[practice.keyNum] == null) {
+        mappedRes[practice.keyNum] = [];
+      }
+      let currentRate = 0;
+      for (const [idx, progress] of res.entries()) {
+        if (progress.practice.practiceId === practice.practiceId) {
+          currentRate = progress.currentRate;
+          res.splice(idx, 1);
+          break;
+        }
+      }
+
+      delete practice.patternInfo.patternId;
+      for (const key in practice.patternInfo) {
+        if (practice.patternInfo[key] === 0) {
+          delete practice.patternInfo[key];
+        }
+      }
+      mappedRes[practice.keyNum].push({
+        goalRate: practice.goalRate,
+        currentRate: currentRate,
+        level: practice.level,
+        title: practice.title,
+        imgSrc: practice.imgSrc,
+        noteSrc: practice.noteSrc,
+        musicSrc: practice.musicSrc,
+        patternInfo: practice.patternInfo,
+      });
+    });
+    return mappedRes;
+  }
+
+  async fetchRanking(id: number) {
+    const practice = await this.practiceService.fetchById(id);
+    if (practice == null) {
+      throw new BadRequestException("해당 패턴 연습은 없습니다.");
+    }
+    const res = await this.progressRepo.find({
+      select: {
+        currentRate: true,
+        updatedAt: true,
+        user: {
+          nickname: true,
+        },
+      },
+      where: {
+        practice: {
+          practiceId: practice.practiceId,
+        },
+      },
+      relations: {
+        user: true,
+      },
+      order: {
+        currentRate: "DESC",
+        updatedAt: "ASC",
+      },
+    });
     return res;
   }
 
@@ -55,18 +152,17 @@ export class PracticeProgressService {
     entity.user = user;
     entity.practice = practice;
     entity.currentRate = progress;
-    return await this.progressRepo.save(entity);
+    const res = await this.progressRepo.save(entity);
+    delete res.user;
+    delete res.practice;
+    return res;
   }
 
   private async __update(progress: number, entity: PracticeProgress) {
     if (entity.currentRate < progress) {
       entity.currentRate = progress;
-      this.progressRepo.update(
-        {
-          practiceProgressId: entity.practiceProgressId,
-        },
-        entity,
-      );
+      return await this.progressRepo.save(entity);
     }
+    return null;
   }
 }

--- a/src/progress/service/progress.service.ts
+++ b/src/progress/service/progress.service.ts
@@ -54,4 +54,20 @@ export class ProgressService {
   async fetchPracticeProgress(userId: number, practiceId: number) {
     return await this.practiceProgressService.fetch(userId, practiceId);
   }
+
+  async fetchAllLevelTestProgress(userId: number, keyNum: number) {
+    return await this.levelTestProgressService.fetchAllByUserId(userId, keyNum);
+  }
+
+  async fetchAllPracticeProgress(userId: number, keyNum: number) {
+    return await this.practiceProgressService.fetchAllByUserId(userId, keyNum);
+  }
+
+  async fetchLevelTestRanking(id: number) {
+    return await this.levelTestProgressService.fetchRanking(id);
+  }
+
+  async fetchPracticeRanking(id: number) {
+    return await this.practiceProgressService.fetchRanking(id);
+  }
 }


### PR DESCRIPTION
1. level-test.service.ts, practice.service.ts
- Fix: entity를 가져올 때 patternInfo도 같이 가져올지 선택하게 수정
- Feat: fetchById로 혹시 모를 검색기능을 대비

2. progress entity
- Feat: 랭킹 기능 추가로 인한 update column 추가

3. **-progress.service
- Fix: 달성도 업데이트에서 반환값을 통일하도록 로직 수정
- Feat: 모든 레벨 테스트/채보 연습에서 유저의 모든 결과를 받아오는 로직 추가
- Fix: 달성도 업데이트 시 update는 updatedAt이 동작하지 않아 save로 변경

4. **-progress.entity
- Append: UpdateDateColumn 추가
- Refactor: 변수 위치 변경

5. progress.controller
- Feat: 모든 레벨 테스트/채보 연습에서 유저의 모든 결과를 받아오는 엔드포인트 추가
- Fix: 모든 return을 res.send()로 하도록 수정
- Refactor: 엔드포인트 경로 수정
- Append: ApiResponse 추가

6. level-test.service, practice.service
- Fix: 패턴 정보를 포함할 것인지 정하는 flag 추가
- Feat: 제목으로 가져오는 로직 추가

7. swagger.object
- Feat: Response 결과를 알려주는 예제 데이터 생성