### PR TITLE
Fix: curl으로 root path에 요청 보낼 시 오류 해결

### DIFF
--- a/src/token/token.guard.ts
+++ b/src/token/token.guard.ts
@@ -35,8 +35,10 @@ export class TokenGuard implements CanActivate {
       if (!isPublic) throw new UnauthorizedException("Token not found");
     }
 
-    cookies.access_token = cookies.access_token.replace("Bearer ", "");
-    cookies.refresh_token = cookies.refresh_token.replace("Bearer ", "");
+    try {
+      cookies.access_token = cookies.access_token.replace("Bearer ", "");
+      cookies.refresh_token = cookies.refresh_token.replace("Bearer ", "");
+    } catch (err) {}
 
     try {
       const decodedAccessToken: TokenPayload =
@@ -55,7 +57,10 @@ export class TokenGuard implements CanActivate {
         response.cookie("access_token", newAccessToken, { httpOnly: true });
         return true;
       } catch (refreshTokenError) {
-        if (isPublic) return true;
+        if (isPublic) {
+          request.user = null;
+          return true;
+        }
         // token expire 시 토큰 자체를 삭제.
         // access_token을 header로 보낼 경우 clearCookie 대신 clearHeader로 바꿔야할듯?
         response.clearCookie("access_token", { httpOnly: true });


### PR DESCRIPTION
token.replace에서 Circular Error 발생 → try catch문으로 해결 중첩
try문에서 isPublic일 경우 request의 user 항목을 null으로 설정