### PR TITLE
Hotfix/enable header login

### DIFF
--- a/src/post/service/post.service.ts
+++ b/src/post/service/post.service.ts
@@ -8,11 +8,13 @@ import { UserService } from "src/user/user.service";
 import { UpdatePostDto } from "../dto/update-post.dto";
 import { PostLikeService } from "./post-like.service";
 import { CommentService } from "src/comment/service/comment.service";
+import { PostLike } from "../entity/post-like.entity";
 
 @Injectable()
 export class PostService {
   constructor(
     @InjectRepository(Post) private postRepository: Repository<Post>,
+    @InjectRepository(PostLike) private postLikeRepository: Repository<PostLike>,
     private readonly boardService: BoardService,
     private readonly userService: UserService,
     private readonly postLikeService: PostLikeService,
@@ -97,16 +99,11 @@ export class PostService {
       },
     });
 
-    const likeCount = await this.postRepository.count({
+    const likeCount = await this.postLikeRepository.count({
       where: {
-        likeList: {
-          post: {
-            id: postId,
-          }
+        post: {
+          id: postId,
         }
-      },
-      relations: {
-        likeList: true
       }
     })
 

--- a/src/post/service/rpost.service.ts
+++ b/src/post/service/rpost.service.ts
@@ -12,11 +12,13 @@ import { RBoardService } from "src/board/service/rboard.service";
 import { UpdatePostDto } from "../dto/update-post.dto";
 import { Comment } from "src/comment/entity/comment.entity";
 import { RPostLikeService } from "./rpost-like.service";
+import { PostLike } from "../entity/post-like.entity";
 
 @Injectable()
 export class RPostService {
   constructor(
     @InjectRepository(Post) private readonly postRepo: Repository<Post>,
+    @InjectRepository(PostLike) private postLikeRepo: Repository<PostLike>,
     private readonly userService: UserService,
     private readonly boardService: RBoardService,
     private readonly postLikeService: RPostLikeService,
@@ -131,6 +133,18 @@ export class RPostService {
         createdAt: "DESC",
       },
     });
+
+    for(const post of posts[0]) {
+      const likeCount = await this.postLikeRepo.count({
+        where: {
+          post: {
+            id: post.id,
+          }
+        }
+      })
+      post["likeCount"] = likeCount;
+    }
+
     this.updatePost(posts, take);
     return { posts: posts[0], allCount: posts[1] };
   }

--- a/src/token/token.guard.ts
+++ b/src/token/token.guard.ts
@@ -12,8 +12,12 @@ import { TokenService } from "./token.service";
 import { cookieOptions } from "./cookie.options";
 
 type Cookies = {
-  access_token: string;
-  refresh_token: string;
+  access_token?: string;
+  refresh_token?: string;
+};
+type Headers = {
+  access_token?: string;
+  refresh_token?: string;
 };
 
 @Injectable()
@@ -31,31 +35,45 @@ export class TokenGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const response = context.switchToHttp().getResponse() as Response;
     const cookies: Cookies = request.cookies as Cookies;
+    const headers: Headers = request.headers as Headers;
 
-    if (!cookies.access_token || !cookies.refresh_token) {
+    const notExistTokenAtCookies = !cookies.access_token || !cookies.refresh_token
+    const notExistTokenAtHeaders = !headers.access_token || !headers.refresh_token
+    
+    if (notExistTokenAtCookies && notExistTokenAtHeaders) {
       if (!isPublic) throw new UnauthorizedException("Token not found");
     }
 
     try {
-      cookies.access_token = cookies.access_token.replace("Bearer ", "");
-      cookies.refresh_token = cookies.refresh_token.replace("Bearer ", "");
+      if(cookies.access_token){
+        cookies.access_token = cookies.access_token.replace("Bearer ", "");
+        cookies.refresh_token = cookies.refresh_token.replace("Bearer ", "");
+      }else {
+        headers.access_token = headers.access_token.replace("Bearer ", "");
+        headers.refresh_token = headers.refresh_token.replace("Bearer ", "");
+      }
     } catch (err) {}
 
     try {
+      const currentAccessToken = cookies.access_token ?? headers.access_token;
+
       const decodedAccessToken: TokenPayload =
-        await this.tokenService.getTokenPayload(cookies.access_token);
+        await this.tokenService.getTokenPayload(currentAccessToken);
       request.user = decodedAccessToken;
       return true;
     } catch (accessTokenError) {
       try {
+        const currentRefreshToken = cookies.refresh_token ?? headers.refresh_token;
+
         const decodedRefreshToken: TokenPayload =
-          await this.tokenService.getTokenPayload(cookies.refresh_token);
+          await this.tokenService.getTokenPayload(currentRefreshToken);
         const newAccessToken = await this.tokenService.signAsync(
           decodedRefreshToken,
           process.env.ACCESS_TOKEN_EXPIRE,
         );
         request.user = decodedRefreshToken;
         response.cookie("access_token", newAccessToken, { ...cookieOptions});
+        response.header("access_token", newAccessToken);
         return true;
       } catch (refreshTokenError) {
         if (isPublic) {


### PR DESCRIPTION
## 👀 요약
1. [feat: v1 댓글 getAll에서 대댓글을 노드 형식으로 반환](https://github.com/rhythm-gamers/rg-back/commit/96ae4f82f762b0ae3540eba8d83bed02547565f1)
2. [fix: v1 post getOne 좋아요 개수 로직을 v2 방식으로 변경](https://github.com/rhythm-gamers/rg-back/commit/0a498150c443b1fe0c69b9037c5ba6d4d5d6fa07)
3. [Feat: v2 post getAll 에서 각 게시글의 좋아요 개수를 반환하도록 추가](https://github.com/rhythm-gamers/rg-back/commit/1f9dce15910b8c0aafea41999e010b9e7b20a6f9)
4. [Feat: header 방식 가드 추가](https://github.com/rhythm-gamers/rg-back/commit/b5d5fe63e426871bb8dfc7a9e8bff348bdeeb375)